### PR TITLE
fix: bugs

### DIFF
--- a/src/models/claim.rs
+++ b/src/models/claim.rs
@@ -21,6 +21,7 @@ pub struct ClaimData {
     pub amount: (Felt, Felt),
     pub target_addr: Address,
     pub tx_id: String,
+    pub tx_vout: u32,
     pub sig: Signature,
 }
 
@@ -31,6 +32,7 @@ pub struct ClaimCalldata {
     pub target_addr: Address,
     pub tx_id: Vec<Felt>,
     pub tx_id_str: String,
+    pub tx_vout: Felt,
     pub sig: Signature,
     pub transaction_struct: Vec<Felt>,
 }

--- a/src/process_block.rs
+++ b/src/process_block.rs
@@ -182,6 +182,7 @@ pub async fn process_deposit_transaction(
                     sig: claim_data.sig,
                     tx_id: hex_to_hash_rev(tx_id),
                     tx_id_str: claim_data.tx_id,
+                    tx_vout: Felt::from(claim_data.tx_vout),
                     transaction_struct,
                 })
                 .await;
@@ -222,6 +223,10 @@ async fn fetch_claim_data(
         );
         let target_addr = Felt::from_hex(claim_data["target_addr"].as_str().unwrap())?;
         let tx_id = claim_data["tx_id"].as_str().unwrap().to_string();
+        let tx_vout = claim_data["tx_vout"]
+            .as_str()
+            .expect("tx_vout is not a string")
+            .parse()?;
         let sig = Signature {
             r: Felt::from_dec_str(claim_data["sig"]["r"].as_str().unwrap())?,
             s: Felt::from_dec_str(claim_data["sig"]["s"].as_str().unwrap())?,
@@ -231,6 +236,7 @@ async fn fetch_claim_data(
             amount,
             target_addr: Address { felt: target_addr },
             tx_id,
+            tx_vout,
             sig,
         })
     } else {

--- a/src/process_block.rs
+++ b/src/process_block.rs
@@ -120,7 +120,7 @@ pub async fn process_block(
         // we fetch 60 txs at a time and a block can have more so
         // we continue fetching until we analyze all txs
         offset += 1;
-        if block_activity.total <= offset * 60 {
+        if offset == block_activity.total {
             break;
         }
     }
@@ -224,9 +224,10 @@ async fn fetch_claim_data(
         let target_addr = Felt::from_hex(claim_data["target_addr"].as_str().unwrap())?;
         let tx_id = claim_data["tx_id"].as_str().unwrap().to_string();
         let tx_vout = claim_data["tx_vout"]
-            .as_str()
-            .expect("tx_vout is not a string")
-            .parse()?;
+            .as_u64()
+            .expect("tx_vout is not a valid number")
+            .try_into()
+            .expect("tx_vout cannot be converted to u32");
         let sig = Signature {
             r: Felt::from_dec_str(claim_data["sig"]["r"].as_str().unwrap())?,
             s: Felt::from_dec_str(claim_data["sig"]["s"].as_str().unwrap())?,

--- a/src/transactions/mod.rs
+++ b/src/transactions/mod.rs
@@ -112,9 +112,7 @@ pub async fn _execute_multicall_common(
     calls: Vec<Call>,
     nonce: Felt,
 ) -> Result<Felt> {
-    let execution = state
-        .starknet_account
-        .execute_v1(calls);
+    let execution = state.starknet_account.execute_v1(calls);
     match execution.estimate_fee().await {
         Ok(_) => match execution
             .nonce(nonce)

--- a/src/utils/starknet.rs
+++ b/src/utils/starknet.rs
@@ -61,6 +61,7 @@ pub async fn prepare_multicall(
                 transaction.target_addr.felt,
             ];
             calldata.extend(transaction.tx_id.iter());
+            calldata.push(transaction.tx_vout);
             calldata.push(transaction.sig.r);
             calldata.push(transaction.sig.s);
             calldata.extend(transaction.transaction_struct.iter());


### PR DESCRIPTION
- Updates the calldata to claim runes to match the changes in the contract (adding vout)
- Fixes process_block, management of offset were incorrect and some results were missing. I though it was `offset*limit = total` but actually total = number of times we need to offset to retrieve all the results given our limit. Close #13 